### PR TITLE
Change output configuration for Vercel adapter to static

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -59,6 +59,6 @@ export default defineConfig({
 		},
 	},
 
-	output: "server",
+	output: "static",
 	adapter: vercel()
 });

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,29 +2,24 @@ import { defineConfig } from "astro/config";
 
 import mdx from "@astrojs/mdx";
 import sitemap from "@astrojs/sitemap";
+import vercel from "@astrojs/vercel";
 import compress from "@playform/compress";
 import tailwindcss from "@tailwindcss/vite";
 import AutoImport from "astro-auto-import";
-import icon from "astro-icon"; // https://www.astroicon.dev/guides/upgrade/v1/
+import icon from "astro-icon";
 
-import vercel from "@astrojs/vercel";
-
-// https://astro.build/config
 export default defineConfig({
 	site: "https://horizon.cosmicthemes.com",
-
+	output: "static",
+	adapter: vercel(),
 	integrations: [
-		// example auto import component into blog post mdx files
 		AutoImport({
 			imports: [
-				// https://github.com/delucis/astro-auto-import
 				"@components/Admonition/Admonition.astro",
 			],
 		}),
 		mdx(),
 		icon({
-			// I include only the icons I use. This is because if you use SSR, ALL icons will be included (no bueno)
-			// https://www.astroicon.dev/reference/configuration#include
 			include: {
 				tabler: [
 					"bulb",
@@ -46,19 +41,15 @@ export default defineConfig({
 			HTML: true,
 			JavaScript: true,
 			CSS: true,
-			Image: false, // astro:assets handles this. Enabling this can dramatically increase build times
-			SVG: false, // astro-icon handles this
+			Image: false,
+			SVG: false,
 		}),
 	],
 
 	vite: {
 		plugins: [tailwindcss()],
-		// stop inlining short scripts to fix issues with ClientRouter: https://github.com/withastro/astro/issues/12804
 		build: {
 			assetsInlineLimit: 0,
 		},
-	},
-
-	output: "static",
-	adapter: vercel()
+	}
 });


### PR DESCRIPTION
### **User description**
Update the output configuration to "static" for the Vercel adapter and refactor the astro.config.mjs accordingly.


___

### **PR Type**
Enhancement


___

### **Description**
- Changed output configuration to `static` for Vercel adapter.

- Refactored `astro.config.mjs` to streamline configuration.

- Removed redundant comments and improved code clarity.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>astro.config.mjs</strong><dd><code>Refactor Astro configuration and set static output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

astro.config.mjs

<li>Changed output configuration from <code>server</code> to <code>static</code>.<br> <li> Configured Vercel adapter with <code>output: "static"</code>.<br> <li> Removed redundant comments and streamlined integrations.<br> <li> Simplified configuration for compress and vite plugins.


</details>


  </td>
  <td><a href="https://github.com/Crise99/boda-nc/pull/9/files#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5f">+7/-16</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>