### PR TITLE
Fix button link to correct experiences page

### DIFF
--- a/src/components/Experience/ExperienceThreeCards.astro
+++ b/src/components/Experience/ExperienceThreeCards.astro
@@ -43,6 +43,6 @@ const firstThreeExperiences = sortedExperiences.slice(0, 3);
 	</div>
 
 	<div class="mt-12 flex justify-center">
-		<Button href="/experience" variant="outline">Ver todas las experiencias</Button>
+		<Button href="/experiences" variant="outline">Ver todas las experiencias</Button>
 	</div>
 </section>


### PR DESCRIPTION
### **User description**
Correct the button link to point to the accurate experiences page.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix incorrect button link in `ExperienceThreeCards.astro`.

- Update link to point to `/experiences` page.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ExperienceThreeCards.astro</strong><dd><code>Fix incorrect button link in `ExperienceThreeCards.astro`</code></dd></summary>
<hr>

src/components/Experience/ExperienceThreeCards.astro

<li>Corrected the button link from <code>/experience</code> to <code>/experiences</code>.<br> <li> Ensured the button now points to the accurate experiences page.


</details>


  </td>
  <td><a href="https://github.com/Crise99/boda-nc/pull/19/files#diff-de8a696d5734d9fccf1e03a57db1666d7fcd285759afc1c6d8f85ac465cc0872">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>