### PR TITLE
Disable CSS compression in Astro configuration

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -41,7 +41,7 @@ export default defineConfig({
 	}), sitemap(), compress({
 		HTML: true,
 		JavaScript: true,
-		CSS: true,
+		// CSS: true,
 		Image: false,
 		SVG: false,
 	}), react()],


### PR DESCRIPTION
Disable CSS compression in the Astro configuration to prevent potential issues during the build process.