### PR TITLE
Import Tailwind theme and clean up styles

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,6 +5,8 @@ import Nav from "@components/Nav/Nav.astro";
 import BaseHead from "@layouts/BaseHead.astro";
 import { Toaster } from "sonner";
 
+/* theme definition import */
+import "@/styles/tailwind-theme.css";
 // style import
 import "@/styles/global.css";
 

--- a/src/pages/invitation.astro
+++ b/src/pages/invitation.astro
@@ -14,9 +14,6 @@ import WeddingCountdown from "@components/WeddingCountdown/WeddingCountdown.astr
 import WeddingSchedule from "@components/WeddingSchedule/WeddingSchedule.astro";
 import heroImage from "@images/mapa.jpg";
 
-// style import
-import "@/styles/global.css";
-
 const title = "Pasaporte a nuestra boda";
 const subtitle = "Despegamos el 08 • 06 • 2025";
 const buttonText = "¿Te vienes?";


### PR DESCRIPTION
Import the Tailwind theme into the BaseLayout and remove the redundant global styles import from the invitation page.