### PR TITLE
Add accommodation information and stay-at-venue option

### DIFF
--- a/src/components/Locations/LocationCard.astro
+++ b/src/components/Locations/LocationCard.astro
@@ -36,7 +36,7 @@ const { icon, title, location, direction, image, buttonText, buttonLink } = Astr
 		<li class="mb-4 text-center">
 			<Image
 				src={image}
-				class="mx-auto h-auto max-w-xs cursor-pointer rounded-md md:max-w-sm"
+				class="mx-auto aspect-4/5 h-96 max-w-xs cursor-pointer rounded-md object-cover md:max-w-sm"
 				alt="Imagen localización"
 				aria-hidden="true"
 				loading="eager"


### PR DESCRIPTION
Introduce a checkbox in the contact form for guests to indicate if they wish to stay at the venue. Update the WeddingEmail and API to handle accommodation preferences. Include a new component to inform guests about available accommodations.

Fixes #78